### PR TITLE
Change TFC patchouli guide Artisinal category sorting

### DIFF
--- a/src/main/resources/assets/tfc/patchouli_books/field_guide/en_us/categories/artisanal.json
+++ b/src/main/resources/assets/tfc/patchouli_books/field_guide/en_us/categories/artisanal.json
@@ -3,5 +3,5 @@
   "name": "Artisanal",
   "description": "Features added by the Artisanal mod.",
   "icon": "artisanal:metal/magnifying_glass/brass",
-  "sortnum": 2
+  "sortnum": 7
 }


### PR DESCRIPTION
Category sorting in English works fine (addon category after 3 of TFC itself 
![image](https://github.com/user-attachments/assets/0e710885-2855-45e3-aa92-ac1bb961baee)

However sorting order changes with different locale due to A-Z sorting
![image](https://github.com/user-attachments/assets/febfa489-02d3-4905-8162-5231aa49ab3e)

It is because standard TFC categories have 0, 1, 2 sorting numbers, while Artisinal also have 2. Changing Artisinals' sorting number will solve the issue and lead to better user experience (TFC guide categories first, addon ones after)