### PR TITLE
Fix: UniversalIngredient test logic

### DIFF
--- a/src/main/java/net/mrhitech/artisanal/common/recipes/inputs/UniversalIngredient.java
+++ b/src/main/java/net/mrhitech/artisanal/common/recipes/inputs/UniversalIngredient.java
@@ -28,6 +28,11 @@ public class UniversalIngredient extends Ingredient {
     public boolean test(@Nullable ItemStack stack) {
         return true;
     }
+
+    @Override
+    public IIngredientSerializer<?> getSerializer() {
+        return Serializer.INSTANCE;
+    }
     
     public enum Serializer implements IIngredientSerializer<UniversalIngredient> {
         INSTANCE;


### PR DESCRIPTION
Fixes Issue #16

### Fix
Add an override for `getSerializer()` in `UniversalIngredient.java` that returns the singleton instance of the internal `Serializer` enum.
